### PR TITLE
add SHA1 of assembly jar to S3 prefix if version is a snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The intention is to allow a build system to set a different, more restrictive bu
 
 By default, `s3Key` will be set to `lambdas/{normalizedName}/{version}/{normalizedName}.jar`.
 
+If the `version` value ends with `-SNAPSHOT`, the SHA1 hash of the assembly JAR will be included in the path.
+
 ### `s3TransferManager`
 
 If custom S3 transfer settings are needed (a different credential strategy, etc.), a `com.amazonaws.services.s3.transfer.TransferManager` can be provided using the `s3TransferManager` setting.

--- a/build.sbt
+++ b/build.sbt
@@ -1,33 +1,22 @@
-import java.lang.System._
-
-lazy val buildVersion = {
-  val mainVersion = "0.2"
-  val minorVersion = Option(getenv("TRAVIS_BUILD_NUMBER"))
-  minorVersion match {
-    case Some(v: String) ⇒ s"$mainVersion.$v"
-    case None ⇒ mainVersion + "-SNAPSHOT"
-  }
-}
-
 lazy val buildSettings = Seq(
   organization := "com.dwolla.sbt",
   name := "sbt-s3-publisher",
   homepage := Some(url("https://github.com/Dwolla/sbt-s3-publisher")),
   description := "SBT plugin to publish an assembled jar to S3",
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
-  version := buildVersion,
+  version := "1.0.0",
   scalaVersion := "2.10.6",
   sbtPlugin := true,
   startYear := Option(2016),
   resolvers += Resolver.bintrayIvyRepo("dwolla", "maven"),
   libraryDependencies ++= {
-    val awsSdkVersion = "1.11.35"
-    val specs2Version = "3.8.5"
+    val awsSdkVersion = "1.11.75"
+    val specs2Version = "3.8.6"
     Seq(
       "com.amazonaws"   %  "aws-java-sdk-s3"              % awsSdkVersion,
       "com.amazonaws"   %  "aws-java-sdk-cloudformation"  % awsSdkVersion,
       "ch.qos.logback"  %  "logback-classic"              % "1.1.7",
-      "com.dwolla"      %% "scala-aws-utils"              % "0.3.19",
+      "com.dwolla"      %% "scala-aws-utils"              % "1.0.0",
       "org.specs2"      %% "specs2-core"                  % specs2Version  % "test",
       "org.specs2"      %% "specs2-mock"                  % specs2Version  % "test"
     )

--- a/src/main/scala/com/dwolla/sbt/awslambda/PublishToS3.scala
+++ b/src/main/scala/com/dwolla/sbt/awslambda/PublishToS3.scala
@@ -25,10 +25,10 @@ object PublishToS3 extends AutoPlugin {
   )
 
   lazy val tasks = Seq(
-    s3Bucket <<= (s3BucketEnvironmentVariable, defaultS3Bucket) map plugin.s3Bucket,
-    s3Prefix <<= (normalizedName, version) map plugin.s3Prefix,
-    s3Key <<= (s3Prefix, normalizedName) map plugin.s3Key,
-    publish <<= (assembly in assembly, s3Bucket, s3Key, streams, s3TransferManager) map plugin.publish
+    s3Bucket := plugin.s3Bucket(s3BucketEnvironmentVariable.value, defaultS3Bucket.value),
+    s3Prefix := plugin.s3Prefix(normalizedName.value, version.value, (assembly in assembly).value),
+    s3Key := plugin.s3Key(s3Prefix.value, normalizedName.value),
+    publish := plugin.publish((assembly in assembly).value, s3Bucket.value, s3Key.value, streams.value, s3TransferManager.value)
   )
 
   lazy val awsLambdaFunctionPluginSettings = Defaults.itSettings ++ defaultValues ++ tasks

--- a/src/main/scala/com/dwolla/sbt/awslambda/S3PublisherPlugin.scala
+++ b/src/main/scala/com/dwolla/sbt/awslambda/S3PublisherPlugin.scala
@@ -4,11 +4,15 @@ import java.io.File
 
 import com.amazonaws.services.s3.transfer.TransferManager
 import com.dwolla.util.{Environment, SystemEnvironment}
+import sbt.Hash
+import sbt.Hash.toHex
 import sbt.Keys.TaskStreams
 
 class S3PublisherPlugin(environment: Environment = SystemEnvironment) {
   val defaultS3Bucket = "dwolla-code-sandbox"
   val defaultBucketEnvironmentVariable = Option("DWOLLA_CODE_BUCKET")
+
+  private val snapshotRegex = "(.*)-SNAPSHOT".r
 
   def publish(artifact: File, bucket: String, s3Key: String, streams: TaskStreams, transferManager: TransferManager) = {
     streams.log.info(s"Uploading «${artifact.getName}» to «s3://$bucket/$s3Key»")
@@ -20,7 +24,12 @@ class S3PublisherPlugin(environment: Environment = SystemEnvironment) {
 
   def s3Key(s3Prefix: String, normalizedName: String) = s"$s3Prefix/$normalizedName.jar"
 
-  def s3Prefix(normalizedName: String, version: String) = s"lambdas/$normalizedName/$version"
+  def s3Prefix(normalizedName: String, version: String, assembly: File) = version match {
+    case snapshotRegex(_) ⇒ s"lambdas/$normalizedName/$version/${sha1(assembly)}"
+    case _ ⇒ s"lambdas/$normalizedName/$version"
+  }
 
   def s3Bucket(envVariable: Option[String], defaultBucketName: String): String = envVariable.flatMap(environment.get).getOrElse(defaultBucketName)
+
+  protected def sha1(jar: File): String = toHex(Hash(jar))
 }


### PR DESCRIPTION
This lets you republish the lambda and redeploy the stack without having to make a commit. Only really matters during development, since it production use each deploy will have its own commit.

(Without a change to the S3 path, CloudFormation wrongly thinks there is nothing to update in the stack, even though the actual contents of the S3 object were being updated.)