### PR TITLE
actually add the release settings to the build definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,4 +62,4 @@ scriptedLaunchOpts := { scriptedLaunchOpts.value ++
 //scriptedBufferLog := false
 
 val s3PublisherPlugin = (project in file("."))
-  .settings(buildSettings ++ bintraySettings: _*)
+  .settings(buildSettings ++ bintraySettings ++ releaseSettings: _*)


### PR DESCRIPTION
Since I forgot to add this in #8, only the sbt 1.0 / Scala 2.12 artifact was [published for version 1.1.0](https://bintray.com/dwolla/sbt-plugins/sbt-s3-publisher/1.1.0#files/com.dwolla.sbt%2Fsbt-s3-publisher%2Fscala_2.12%2Fsbt_1.0%2F1.1.0). This should cross publish sbt 0.13 and 1.0 artifacts as 1.1.1 (and going forward).