### PR TITLE
Fix gitRunner.apply to use correct args

### DIFF
--- a/src/main/scala/com/dwolla/sbt/s3/PublishToS3.scala
+++ b/src/main/scala/com/dwolla/sbt/s3/PublishToS3.scala
@@ -30,7 +30,7 @@ object PublishToS3 extends AutoPlugin {
   )
 
   private def publishBranchIsCheckedOut(branch: String, headCommit: Option[String], gitRunner: GitRunner, workingDirectory: File, log: Logger): Boolean =
-    headCommit.contains(gitRunner(s"rev-parse $branch")(workingDirectory, log))
+    headCommit.contains(gitRunner("rev-parse", branch)(workingDirectory, log))
 
   lazy val tasks = Seq(
     s3PublishSnapshot := !(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.0-SNAPSHOT"
+version in ThisBuild := "1.3.1-SNAPSHOT"


### PR DESCRIPTION
Without this, the plugin tries to run git with the argument of `rev-parse master`, which isn't a git command.

The fix changes it to run git `rev-parse` `master`, which is a git command.